### PR TITLE
Detect configs inside an nginx directory

### DIFF
--- a/ftdetect/nginx.vim
+++ b/ftdetect/nginx.vim
@@ -3,3 +3,4 @@ au BufRead,BufNewFile nginx*.conf set ft=nginx
 au BufRead,BufNewFile *nginx.conf set ft=nginx
 au BufRead,BufNewFile */etc/nginx/* set ft=nginx
 au BufRead,BufNewFile */usr/local/nginx/conf/* set ft=nginx
+au BufRead,BufNewFile */nginx/*.conf set ft=nginx


### PR DESCRIPTION
Inside Rails projects we store our nginx configs inside the directory `config/nginx/` so I added this path to the `ftdetect` list.