### PR TITLE
Added deprecated directive limit_zone by accident.

### DIFF
--- a/syntax/nginx.vim
+++ b/syntax/nginx.vim
@@ -310,7 +310,6 @@ syn keyword ngxDirective limit_req_dry_run
 syn keyword ngxDirective limit_req_log_level
 syn keyword ngxDirective limit_req_status
 syn keyword ngxDirective limit_req_zone
-syn keyword ngxDirective limit_zone
 syn keyword ngxDirective lingering_close
 syn keyword ngxDirective lingering_time
 syn keyword ngxDirective lingering_timeout


### PR DESCRIPTION
Seems I was a bit trigger happy and added a directive that was already marked as deprecated, limit_zone.
This PR fixes this.