### PR TITLE
Remove explicit Normal link for ngxBlock

### DIFF
--- a/syntax/nginx.vim
+++ b/syntax/nginx.vim
@@ -2276,7 +2276,6 @@ hi link ngxComment Comment
 hi link ngxVariable Identifier
 hi link ngxVariableBlock Identifier
 hi link ngxVariableString PreProc
-hi link ngxBlock Normal
 hi link ngxString String
 hi link ngxIPaddr Delimiter
 hi link ngxBoolean Boolean


### PR DESCRIPTION
ngxBlocks are grouping mechanisms, they can rely on the default
background provided by other tools. This resolves syntax highlighting
discrepancies when using things like floating windows (where the
background color might highlight with NormalFloat in Neovim, for
example).

## Before

![nginx-normal-before](https://user-images.githubusercontent.com/3723671/109215851-9aa8f400-7768-11eb-8b50-a7e3fd16759b.png)

## After

![nginx-after](https://user-images.githubusercontent.com/3723671/109215856-9c72b780-7768-11eb-8143-973915b3bbb2.png)